### PR TITLE
fix: incorrect year for generated ics file

### DIFF
--- a/src/components/Modal/BOSSTimetable/index.tsx
+++ b/src/components/Modal/BOSSTimetable/index.tsx
@@ -54,11 +54,12 @@ const Wrapper = styled.div`
     .content {
       display: flex;
       flex-wrap: wrap;
-      justify-content: space-between;
+      justify-content: flex-start;
 
       label {
         color: ${(props) => props.theme.text900};
         margin-top: 4px;
+        padding-right: 1rem;
       }
     }
   }

--- a/src/components/Modal/BOSSTimetable/index.tsx
+++ b/src/components/Modal/BOSSTimetable/index.tsx
@@ -95,7 +95,6 @@ const HelperText = styled.div`
 function convert(data: string[][], allowedModules: string[] = []) {
   // Remove CSV header
   const relevantData = data.slice(1);
-
   const meetings = parseMeetings(relevantData);
 
   const events: Event[] = meetings
@@ -125,9 +124,18 @@ function convert(data: string[][], allowedModules: string[] = []) {
       const firstDate = termStart.clone();
       firstDate.day(dayOfWeek);
 
-      const dtStart = moment(`${firstDate.format('DD-MMM-yyyy')} ${timeStart}`);
-      const dtEnd = moment(`${firstDate.format('DD-MMM-yyyy')} ${timeEnd}`);
-      const repeatEnd = moment(`${termEnd.format('DD-MMM-yyyy')} ${timeEnd}`);
+      const dtStart = moment(
+        `${firstDate.format('DD-MMM-yyyy')} ${timeStart}`,
+        'DD-MMM-yyyy HH:mm'
+      );
+      const dtEnd = moment(
+        `${firstDate.format('DD-MMM-yyyy')} ${timeEnd}`,
+        'DD-MMM-yyyy HH:mm'
+      );
+      const repeatEnd = moment(
+        `${termEnd.format('DD-MMM-yyyy')} ${timeEnd}`,
+        'DD-MMM-yyyy HH:mm'
+      );
 
       return {
         summary: `${classCode} (${classDesc}) ${capitalize(type)}`,

--- a/src/components/Modal/BOSSTimetable/util/parseMeetings.ts
+++ b/src/components/Modal/BOSSTimetable/util/parseMeetings.ts
@@ -31,7 +31,7 @@ export default function parseMeetings(data: string[][]): Meeting[] {
     const instructor = event[14];
 
     const dayOfWeek = event[10];
-    const startDateActual = moment(startDate);
+    const startDateActual = moment(startDate, 'DD-MMM-YYYY');
     startDateActual.day(dayOfWeek);
 
     return {
@@ -39,8 +39,8 @@ export default function parseMeetings(data: string[][]): Meeting[] {
       classDesc,
       section,
       type: type as Meeting['type'],
-      termStart: moment(startDate),
-      termEnd: moment(endDate),
+      termStart: moment(startDate, 'DD-MMM-YYYY'),
+      termEnd: moment(endDate, 'DD-MMM-YYYY'),
       timeStart: startTime,
       timeEnd: endTime,
       venue,


### PR DESCRIPTION
#51 
Firefox may parse the date wrongly in some cases. This PR adds formatting to moment.js to tell the browser the format the dateString passed to it.

## Changes
- fix: invalid date formatting
- refactor: increase module selection spacing