### PR TITLE
feat(theme): Add user-selectable color themes

### DIFF
--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -7,15 +7,18 @@ import { AppProps } from 'next/app';
 import React from 'react';
 
 import { DataWrapper } from '../screens/smu/contexts/DataContext';
+import { ThemeWrapper } from '../shared/contexts/ThemeContext';
 
 const App: React.FC<AppProps> = function (props) {
   const { Component, pageProps } = props;
 
   return (
-    <DataWrapper>
-      <Component {...pageProps} />
-      <Analytics />
-    </DataWrapper>
+    <ThemeWrapper>
+      <DataWrapper>
+        <Component {...pageProps} />
+        <Analytics />
+      </DataWrapper>
+    </ThemeWrapper>
   );
 };
 

--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -4,6 +4,20 @@ export default function Document() {
   return (
     <Html lang="en">
       <Head>
+        <script
+          dangerouslySetInnerHTML={{
+            __html: `
+              (function () {
+                try {
+                  var theme = localStorage.getItem('classmaid-theme');
+                  if (theme) {
+                    document.documentElement.setAttribute('data-theme', theme);
+                  }
+                } catch (e) {}
+              })();
+            `,
+          }}
+        />
         <link
           rel="stylesheet"
           href="https://fonts.googleapis.com/css2?family=Material+Symbols+Rounded:opsz,wght,FILL,GRAD@48,400,0,0&display=swap"

--- a/src/screens/smu/components/widget/LibraryCapacities/components/Header.tsx
+++ b/src/screens/smu/components/widget/LibraryCapacities/components/Header.tsx
@@ -15,10 +15,10 @@ const Header: React.FC = function () {
         className={classnames(
           'cursor-pointer no-underline rounded-2xl',
           'flex p-2 -mr-2 items-center border-none bg-transparent',
-          'hover:bg-sky-200 dark:hover:bg-sky-200'
+          'hover:bg-theme-200'
         )}
       >
-        <Icon name="open_in_new" className="text-sky-500 dark:text-sky-500" />
+        <Icon name="open_in_new" className="text-theme-500" />
       </a>
     </WidgetHeader>
   );

--- a/src/screens/smu/components/widget/LibraryCapacities/components/LibraryOccupancySection/components/Library.tsx
+++ b/src/screens/smu/components/widget/LibraryCapacities/components/LibraryOccupancySection/components/Library.tsx
@@ -46,7 +46,7 @@ const Library: React.FC<Props> = function (props) {
         )}
       >
         <div>
-          <h1 className="m-0 mb-1 text-[1.15em] text-white capitalize">
+          <h1 className="text-xl font-medium text-white capitalize">
             {name.toLowerCase()}
           </h1>
           <div className="flex flex-row items-center">
@@ -60,12 +60,9 @@ const Library: React.FC<Props> = function (props) {
           </div>
         </div>
 
-        <span className="text-[0.65em] text-gray-50">
+        <span className="text-xs text-gray-50">
           {author},{' '}
-          <a
-            href={license.externalUrl}
-            className="text-sky-500 dark:text-sky-500"
-          >
+          <a href={license.externalUrl} className="text-theme-500">
             {license.type}
           </a>
           {', '}

--- a/src/screens/smu/components/widget/LibraryCapacities/components/LibraryOccupancySection/components/ProgressCircle.tsx
+++ b/src/screens/smu/components/widget/LibraryCapacities/components/LibraryOccupancySection/components/ProgressCircle.tsx
@@ -6,7 +6,7 @@ interface Props {
 }
 
 const width = 40;
-const strokeWidth = 12;
+const strokeWidth = 10;
 const radius = 100 / 2 - strokeWidth * 2;
 const circumference = radius * 2 * Math.PI;
 
@@ -29,7 +29,7 @@ const ProgressCircle: React.FC<Props> = function (props) {
         xmlns="http://www.w3.org/2000/svg"
       >
         <circle
-          className="fill-transparent stroke-sky-100 dark:stroke-sky-100"
+          className="fill-transparent stroke-theme-200 dark:stroke-theme-300"
           cx="50"
           cy="50"
           r={radius}
@@ -37,7 +37,7 @@ const ProgressCircle: React.FC<Props> = function (props) {
           strokeLinecap="round"
         />
         <circle
-          className="fill-transparent stroke-sky-500 dark:stroke-sky-500 -rotate-90 origin-center transition-[stroke-dashoffset] duration-500 ease-out"
+          className="fill-transparent stroke-theme-500 dark:stroke-theme-600 -rotate-90 origin-center transition-[stroke-dashoffset] duration-500 ease-out"
           cx="50"
           cy="50"
           r={radius}

--- a/src/screens/smu/components/widget/TodaySummary/components/TodayEvent.tsx
+++ b/src/screens/smu/components/widget/TodaySummary/components/TodayEvent.tsx
@@ -69,7 +69,7 @@ const TodayEvent: React.FC<Props> = function (props) {
             <h1 className={EventTitleClassName}>{event?.title}</h1>
             <span className="font-semibold px-2 text-lg">OF</span>
           </div>
-          <h1 className={classnames(EventTitleClassName, 'text-theme-500 ')}>
+          <h1 className={classnames(EventTitleClassName, 'text-theme-500')}>
             {event.type.toUpperCase()}
           </h1>
         </>
@@ -77,7 +77,7 @@ const TodayEvent: React.FC<Props> = function (props) {
     }
 
     return (
-      <h1 className={classnames(EventTitleClassName, 'text-theme-500 ')}>
+      <h1 className={classnames(EventTitleClassName, 'text-theme-500')}>
         {event.title}
       </h1>
     );
@@ -97,7 +97,7 @@ const TodayEvent: React.FC<Props> = function (props) {
       >
         <Icon
           name="open_in_full"
-          className="text-theme-500 dark:text-theme-500"
+          className="text-theme-500"
         />
       </Link>
     </div>

--- a/src/screens/smu/components/widget/TodaySummary/components/TodayEvent.tsx
+++ b/src/screens/smu/components/widget/TodaySummary/components/TodayEvent.tsx
@@ -69,7 +69,7 @@ const TodayEvent: React.FC<Props> = function (props) {
             <h1 className={EventTitleClassName}>{event?.title}</h1>
             <span className="font-semibold px-2 text-lg">OF</span>
           </div>
-          <h1 className={classnames(EventTitleClassName, ' text-sky-500 ')}>
+          <h1 className={classnames(EventTitleClassName, 'text-theme-500 ')}>
             {event.type.toUpperCase()}
           </h1>
         </>
@@ -77,7 +77,7 @@ const TodayEvent: React.FC<Props> = function (props) {
     }
 
     return (
-      <h1 className={classnames(EventTitleClassName, 'text-sky-500 ')}>
+      <h1 className={classnames(EventTitleClassName, 'text-theme-500 ')}>
         {event.title}
       </h1>
     );
@@ -92,10 +92,13 @@ const TodayEvent: React.FC<Props> = function (props) {
         href="/smu/calendar"
         className={classnames(
           'no-underline rounded-2xl flex p-2',
-          'hover:bg-sky-200'
+          'hover:bg-theme-200'
         )}
       >
-        <Icon name="open_in_full" className="text-sky-500 dark:text-sky-500" />
+        <Icon
+          name="open_in_full"
+          className="text-theme-500 dark:text-theme-500"
+        />
       </Link>
     </div>
   );

--- a/src/screens/smu/components/widget/styled.tsx
+++ b/src/screens/smu/components/widget/styled.tsx
@@ -30,7 +30,7 @@ export const WidgetHeader = React.forwardRef<HTMLDivElement, WidgetHeaderProps>(
     <div
       ref={ref}
       className={classnames(
-        'box-border px-4 h-16 flex items-center bg-sky-100 dark:bg-sky-800',
+        'box-border px-4 h-16 flex items-center bg-theme-100 dark:bg-theme-950',
         className
       )}
       {...props}

--- a/src/screens/smu/pages/home/components/BOSSTimetableModal/index.tsx
+++ b/src/screens/smu/pages/home/components/BOSSTimetableModal/index.tsx
@@ -245,10 +245,9 @@ const BOSSTimetableModal: React.FC = () => {
           className={classnames(
             'flex justify-center font-medium text-base p-3',
             'text-white rounded-xl no-underline',
-            'border-2 border-sky-300 dark:border-sky-300',
-            'bg-sky-500 dark:bg-sky-500',
-            'hover:text-sky-500 hover:bg-sky-100',
-            'dark:hover:text-sky-500 dark:hover:bg-sky-100'
+            'border-2 border-theme-300 bg-theme-500',
+            'hover:text-theme-500 hover:bg-theme-100',
+            'dark:hover:text-theme-500 dark:hover:bg-theme-100'
           )}
         >
           Download

--- a/src/screens/smu/shared/components/FilePicker.tsx
+++ b/src/screens/smu/shared/components/FilePicker.tsx
@@ -59,8 +59,8 @@ const FilePicker: React.FC<Props> = (props) => {
         className={classnames(
           'inline-block cursor-pointer rounded-2xl',
           'bg-gray-200 dark:bg-gray-700',
-          'w-1/2 max-w-112.5 p-4',
-          'hover:bg-sky-100 dark:hover:bg-sky-100'
+          'w-1/2 max-w-md p-4',
+          'hover:bg-theme-100'
         )}
       >
         <span
@@ -69,7 +69,7 @@ const FilePicker: React.FC<Props> = (props) => {
             'text-gray-700 dark:text-gray-200',
             'overflow-hidden text-ellipsis',
             !newLabel && 'text-gray-500 dark:text-gray-300',
-            !newLabel && 'hover:text-sky-300 dark:hover:text-sky-300'
+            !newLabel && 'hover:text-theme-300'
           )}
         >
           <Icon name="file_upload" />

--- a/src/shared/components/SEO.tsx
+++ b/src/shared/components/SEO.tsx
@@ -18,9 +18,7 @@ const SEO: React.FC<Props> = function (props) {
 
   return (
     <Head>
-      <title>
-        {title} | {siteMetadata.title}
-      </title>
+      <title>{`${title} | ${siteMetadata.title}`}</title>
       <meta
         name="viewport"
         content="width=device-width, initial-scale=1.0, viewport-fit=cover"

--- a/src/shared/components/navigation/NavHeader/components/AboutModal.tsx
+++ b/src/shared/components/navigation/NavHeader/components/AboutModal.tsx
@@ -34,7 +34,7 @@ const AboutModal: React.FC<Props> = function (props) {
               {'Current or incoming student? Make a suggestion '}
               <a
                 href="https://bit.ly/30SRyIo"
-                className="text-sky-500 dark:text-sky-500"
+                className="text-theme-500 dark:text-theme-500"
               >
                 here
               </a>
@@ -43,7 +43,7 @@ const AboutModal: React.FC<Props> = function (props) {
               {'Developer? Add an issue or make a pull request on '}
               <a
                 href="https://github.com/alphatrl/classmaid"
-                className="text-sky-500 dark:text-sky-500"
+                className="text-theme-500 dark:text-theme-500"
               >
                 Github
               </a>

--- a/src/shared/components/navigation/NavHeader/components/AboutModal.tsx
+++ b/src/shared/components/navigation/NavHeader/components/AboutModal.tsx
@@ -34,7 +34,7 @@ const AboutModal: React.FC<Props> = function (props) {
               {'Current or incoming student? Make a suggestion '}
               <a
                 href="https://bit.ly/30SRyIo"
-                className="text-theme-500 dark:text-theme-500"
+                className="text-theme-500"
               >
                 here
               </a>
@@ -43,7 +43,7 @@ const AboutModal: React.FC<Props> = function (props) {
               {'Developer? Add an issue or make a pull request on '}
               <a
                 href="https://github.com/alphatrl/classmaid"
-                className="text-theme-500 dark:text-theme-500"
+                className="text-theme-500"
               >
                 Github
               </a>

--- a/src/shared/components/navigation/NavHeader/components/AddToHomeModal.tsx
+++ b/src/shared/components/navigation/NavHeader/components/AddToHomeModal.tsx
@@ -19,7 +19,7 @@ const AddToHomeModal: React.FC<Props> = function (props) {
         <ol className="list-decimal leading-8 px-4">
           <li>
             Tap{' '}
-            <span className="material-symbols-rounded text-sky-500 dark:text-sky-500 align-text-bottom">
+            <span className="material-symbols-rounded text-theme-500 dark:text-theme-500 align-text-bottom">
               {'ios_share'}
             </span>
             .
@@ -33,7 +33,7 @@ const AddToHomeModal: React.FC<Props> = function (props) {
       <ol className="list-decimal leading-8 px-4">
         <li>
           Tap on <b>More Options</b>
-          <span className="material-symbols-rounded text-sky-500 dark:text-sky-500 align-text-bottom">
+          <span className="material-symbols-rounded text-theme-500 dark:text-theme-500 align-text-bottom">
             {'more_vert'}
           </span>
           .

--- a/src/shared/components/navigation/NavHeader/components/AddToHomeModal.tsx
+++ b/src/shared/components/navigation/NavHeader/components/AddToHomeModal.tsx
@@ -19,7 +19,7 @@ const AddToHomeModal: React.FC<Props> = function (props) {
         <ol className="list-decimal leading-8 px-4">
           <li>
             Tap{' '}
-            <span className="material-symbols-rounded text-theme-500 dark:text-theme-500 align-text-bottom">
+            <span className="material-symbols-rounded text-theme-500 align-text-bottom">
               {'ios_share'}
             </span>
             .
@@ -33,7 +33,7 @@ const AddToHomeModal: React.FC<Props> = function (props) {
       <ol className="list-decimal leading-8 px-4">
         <li>
           Tap on <b>More Options</b>
-          <span className="material-symbols-rounded text-theme-500 dark:text-theme-500 align-text-bottom">
+          <span className="material-symbols-rounded text-theme-500 align-text-bottom">
             {'more_vert'}
           </span>
           .

--- a/src/shared/components/navigation/NavHeader/components/MoreButton/components/ThemeSubmenu.tsx
+++ b/src/shared/components/navigation/NavHeader/components/MoreButton/components/ThemeSubmenu.tsx
@@ -1,0 +1,66 @@
+import classnames from 'classnames';
+import { DropdownMenu } from 'radix-ui';
+import React from 'react';
+
+import { useTheme } from '../../../../../../contexts/ThemeContext';
+import Icon from '../../../../../Icon';
+
+const themeDotColors: Record<string, string> = {
+  blue: 'bg-blue-500',
+  red: 'bg-red-500',
+  emerald: 'bg-emerald-500',
+  pink: 'bg-pink-500',
+};
+
+const themeLabels: Record<string, string> = {
+  blue: 'Blue',
+  red: 'Red',
+  emerald: 'Emerald',
+  pink: 'Pink',
+};
+
+interface Props {
+  itemClassName: string;
+}
+
+const ThemeSubmenu: React.FC<Props> = function (props) {
+  const { itemClassName } = props;
+  const { theme, setTheme, themes } = useTheme();
+
+  return (
+    <DropdownMenu.Sub>
+      <DropdownMenu.SubTrigger className={itemClassName}>
+        <Icon name="palette" />
+        <DropdownMenu.Label>Theme</DropdownMenu.Label>
+      </DropdownMenu.SubTrigger>
+      <DropdownMenu.Portal>
+        <DropdownMenu.SubContent
+          sideOffset={0}
+          className={classnames(
+            'min-w-44 rounded-2xl p-1.5 overflow-hidden z-10',
+            'bg-white dark:bg-gray-900 shadow-2xl'
+          )}
+        >
+          {themes.map((t) => (
+            <DropdownMenu.Item
+              key={t}
+              className={itemClassName}
+              onSelect={() => setTheme(t)}
+            >
+              <span
+                className={classnames(
+                  'w-4 h-4 rounded-full',
+                  themeDotColors[t]
+                )}
+              />
+              {themeLabels[t]}
+              {theme === t && <Icon name="check" className="ml-auto" />}
+            </DropdownMenu.Item>
+          ))}
+        </DropdownMenu.SubContent>
+      </DropdownMenu.Portal>
+    </DropdownMenu.Sub>
+  );
+};
+
+export default ThemeSubmenu;

--- a/src/shared/components/navigation/NavHeader/components/MoreButton/components/ThemeSubmenu.tsx
+++ b/src/shared/components/navigation/NavHeader/components/MoreButton/components/ThemeSubmenu.tsx
@@ -2,21 +2,14 @@ import classnames from 'classnames';
 import { DropdownMenu } from 'radix-ui';
 import React from 'react';
 
-import { useTheme } from '../../../../../../contexts/ThemeContext';
+import { Theme, useTheme } from '../../../../../../contexts/ThemeContext';
 import Icon from '../../../../../Icon';
 
-const themeDotColors: Record<string, string> = {
-  blue: 'bg-blue-500',
-  red: 'bg-red-500',
-  emerald: 'bg-emerald-500',
-  pink: 'bg-pink-500',
-};
-
-const themeLabels: Record<string, string> = {
-  blue: 'Blue',
-  red: 'Red',
-  emerald: 'Emerald',
-  pink: 'Pink',
+const themeMeta: Record<Theme, { dot: string; label: string }> = {
+  blue: { dot: 'bg-blue-500', label: 'Blue' },
+  red: { dot: 'bg-red-500', label: 'Red' },
+  emerald: { dot: 'bg-emerald-500', label: 'Emerald' },
+  pink: { dot: 'bg-pink-500', label: 'Pink' },
 };
 
 interface Props {
@@ -50,10 +43,10 @@ const ThemeSubmenu: React.FC<Props> = function (props) {
               <span
                 className={classnames(
                   'w-4 h-4 rounded-full',
-                  themeDotColors[t]
+                  themeMeta[t].dot
                 )}
               />
-              {themeLabels[t]}
+              {themeMeta[t].label}
               {theme === t && <Icon name="check" className="ml-auto" />}
             </DropdownMenu.Item>
           ))}

--- a/src/shared/components/navigation/NavHeader/components/MoreButton/index.tsx
+++ b/src/shared/components/navigation/NavHeader/components/MoreButton/index.tsx
@@ -2,11 +2,12 @@ import classnames from 'classnames';
 import { DropdownMenu } from 'radix-ui';
 import React from 'react';
 
-import useMediaQuery from '../../../../hooks/useMediaQuery';
-import useMobileDevice from '../../../../hooks/useMobileDevice';
-import Icon from '../../../Icon';
-import AboutModal from './AboutModal';
-import AddToHomeModal from './AddToHomeModal';
+import useMediaQuery from '../../../../../hooks/useMediaQuery';
+import useMobileDevice from '../../../../../hooks/useMobileDevice';
+import Icon from '../../../../Icon';
+import AboutModal from '../AboutModal';
+import AddToHomeModal from '../AddToHomeModal';
+import ThemeSubmenu from './components/ThemeSubmenu';
 
 const ItemClassName = classnames(
   'text-base flex items-center gap-2 px-2 py-0.5 min-h-12',
@@ -45,7 +46,7 @@ const MoreButton: React.FC = function () {
         <DropdownMenu.Trigger asChild>
           <button
             className={classnames(
-              'py-2.5 px-3 rounded-lg bg-transparent border-none',
+              'py-3 px-3 rounded-lg bg-transparent border-none',
               'text-white cursor-pointer flex items-center hover:bg-black/20'
             )}
           >
@@ -57,7 +58,7 @@ const MoreButton: React.FC = function () {
             align="end"
             sideOffset={0}
             className={classnames(
-              'min-w-60 max-w-80 rounded-2xl p-1 overflow-hidden z-10',
+              'min-w-60 max-w-80 rounded-2xl p-1.5 overflow-hidden z-10',
               'bg-white dark:bg-gray-900 shadow-2xl'
             )}
           >
@@ -78,6 +79,7 @@ const MoreButton: React.FC = function () {
                 Add to Home Screen
               </DropdownMenu.Item>
             )}
+            <ThemeSubmenu itemClassName={ItemClassName} />
           </DropdownMenu.Content>
         </DropdownMenu.Portal>
       </DropdownMenu.Root>

--- a/src/shared/contexts/ThemeContext.tsx
+++ b/src/shared/contexts/ThemeContext.tsx
@@ -1,0 +1,53 @@
+import React from 'react';
+
+const THEME_STORAGE_KEY = 'classmaid-theme';
+const THEMES = ['blue', 'red', 'emerald', 'pink'] as const;
+type Theme = (typeof THEMES)[number];
+const DEFAULT_THEME: Theme = 'blue';
+
+interface ThemeContextProps {
+  theme: Theme;
+  setTheme: (theme: Theme) => void;
+  themes: readonly Theme[];
+}
+
+const ThemeContext = React.createContext<ThemeContextProps>({
+  theme: DEFAULT_THEME,
+  setTheme: () => {},
+  themes: THEMES,
+});
+
+export const ThemeWrapper: React.FC<React.PropsWithChildren> = ({
+  children,
+}) => {
+  const [theme, setThemeState] = React.useState<Theme>(DEFAULT_THEME);
+
+  React.useEffect(() => {
+    const stored = localStorage.getItem(THEME_STORAGE_KEY);
+    if (stored && THEMES.includes(stored as Theme)) {
+      setThemeState(stored as Theme);
+      document.documentElement.setAttribute('data-theme', stored);
+    } else {
+      document.documentElement.setAttribute('data-theme', DEFAULT_THEME);
+    }
+  }, []);
+
+  const setTheme = React.useCallback((newTheme: Theme) => {
+    setThemeState(newTheme);
+    localStorage.setItem(THEME_STORAGE_KEY, newTheme);
+    document.documentElement.setAttribute('data-theme', newTheme);
+  }, []);
+
+  const value = React.useMemo(
+    () => ({ theme, setTheme, themes: THEMES }),
+    [theme, setTheme]
+  );
+
+  return (
+    <ThemeContext.Provider value={value}>{children}</ThemeContext.Provider>
+  );
+};
+
+export const useTheme = (): ThemeContextProps => {
+  return React.useContext(ThemeContext);
+};

--- a/src/shared/contexts/ThemeContext.tsx
+++ b/src/shared/contexts/ThemeContext.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 const THEME_STORAGE_KEY = 'classmaid-theme';
 const THEMES = ['blue', 'red', 'emerald', 'pink'] as const;
-type Theme = (typeof THEMES)[number];
+export type Theme = (typeof THEMES)[number];
 const DEFAULT_THEME: Theme = 'blue';
 
 interface ThemeContextProps {

--- a/src/shared/contexts/ThemeContext.tsx
+++ b/src/shared/contexts/ThemeContext.tsx
@@ -20,17 +20,15 @@ const ThemeContext = React.createContext<ThemeContextProps>({
 export const ThemeWrapper: React.FC<React.PropsWithChildren> = ({
   children,
 }) => {
-  const [theme, setThemeState] = React.useState<Theme>(DEFAULT_THEME);
-
-  React.useEffect(() => {
-    const stored = localStorage.getItem(THEME_STORAGE_KEY);
-    if (stored && THEMES.includes(stored as Theme)) {
-      setThemeState(stored as Theme);
-      document.documentElement.setAttribute('data-theme', stored);
-    } else {
-      document.documentElement.setAttribute('data-theme', DEFAULT_THEME);
+  const [theme, setThemeState] = React.useState<Theme>(() => {
+    if (typeof window === 'undefined') {
+      return DEFAULT_THEME;
     }
-  }, []);
+    const stored = localStorage.getItem(THEME_STORAGE_KEY);
+    return stored && THEMES.includes(stored as Theme)
+      ? (stored as Theme)
+      : DEFAULT_THEME;
+  });
 
   const setTheme = React.useCallback((newTheme: Theme) => {
     setThemeState(newTheme);

--- a/src/styles/calendar.css
+++ b/src/styles/calendar.css
@@ -17,7 +17,7 @@
 }
 
 .calendar-wrapper .react-calendar__tile--now abbr {
-  @apply font-semibold text-sky-500;
+  @apply font-semibold text-theme-500;
 }
 
 .calendar-wrapper .react-calendar__tile--now {
@@ -37,18 +37,18 @@
 }
 
 .calendar-wrapper .react-calendar__tile--active {
-  @apply bg-sky-300 text-sky-500;
+  @apply bg-theme-300 text-theme-500;
 }
 
 .dark .calendar-wrapper .react-calendar__tile--active {
-  @apply bg-sky-300;
+  @apply bg-theme-300;
 }
 
 .calendar-wrapper .react-calendar__tile:enabled:hover,
 .calendar-wrapper .react-calendar__tile:enabled:focus,
 .calendar-wrapper .react-calendar__tile--active:enabled:hover,
 .calendar-wrapper .react-calendar__tile--active:enabled:focus {
-  @apply bg-sky-100;
+  @apply bg-theme-100;
 }
 
 .calendar-wrapper .react-calendar__month-view__days__day--neighboringMonth {

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -1,11 +1,83 @@
 @import 'tailwindcss';
 @import 'tailwindcss-safe-area';
 
-/** 
+/**
   * Stylings for react-calendar
   */
 @import 'react-calendar/dist/Calendar.css';
 @import './calendar.css';
+
+@theme {
+  --color-theme-50: var(--theme-50);
+  --color-theme-100: var(--theme-100);
+  --color-theme-200: var(--theme-200);
+  --color-theme-300: var(--theme-300);
+  --color-theme-400: var(--theme-400);
+  --color-theme-500: var(--theme-500);
+  --color-theme-600: var(--theme-600);
+  --color-theme-700: var(--theme-700);
+  --color-theme-800: var(--theme-800);
+  --color-theme-900: var(--theme-900);
+  --color-theme-950: var(--theme-950);
+}
+
+/* Blue (default) */
+:root,
+[data-theme='blue'] {
+  --theme-50: #eff6ff;
+  --theme-100: #dbeafe;
+  --theme-200: #bfdbfe;
+  --theme-300: #93c5fd;
+  --theme-400: #60a5fa;
+  --theme-500: #3b82f6;
+  --theme-600: #2563eb;
+  --theme-700: #1d4ed8;
+  --theme-800: #1e40af;
+  --theme-900: #1e3a8a;
+  --theme-950: #172554;
+}
+
+[data-theme='red'] {
+  --theme-50: #fef2f2;
+  --theme-100: #fee2e2;
+  --theme-200: #fecaca;
+  --theme-300: #fca5a5;
+  --theme-400: #f87171;
+  --theme-500: #ef4444;
+  --theme-600: #dc2626;
+  --theme-700: #b91c1c;
+  --theme-800: #991b1b;
+  --theme-900: #7f1d1d;
+  --theme-950: #450a0a;
+}
+
+[data-theme='emerald'] {
+  --theme-50: #ecfdf5;
+  --theme-100: #d1fae5;
+  --theme-200: #a7f3d0;
+  --theme-300: #6ee7b7;
+  --theme-400: #34d399;
+  --theme-500: #10b981;
+  --theme-600: #059669;
+  --theme-700: #047857;
+  --theme-800: #065f46;
+  --theme-900: #064e3b;
+  --theme-950: #022c22;
+}
+
+[data-theme='pink'] {
+  --theme-50: #fdf2f8;
+  --theme-100: #fce7f3;
+  --theme-200: #fbcfe8;
+  --theme-300: #f9a8d4;
+  --theme-400: #f472b6;
+  --theme-500: #ec4899;
+  --theme-600: #db2777;
+  --theme-700: #be185d;
+  --theme-800: #9d174d;
+  --theme-900: #831843;
+  --theme-950: #500724;
+}
 
 body {
   margin: 0;
@@ -14,7 +86,7 @@ body {
     'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue', sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
-  @apply text-gray-700 bg-sky-300 dark:text-gray-200 dark:bg-sky-300;
+  @apply text-gray-700 bg-theme-300 dark:text-gray-200 dark:bg-theme-300;
 }
 
 html {


### PR DESCRIPTION
# Purpose

Introduce a theme system that lets users switch between color themes (Blue, Red, Emerald, Pink) from the navigation menu. The selected theme persists across sessions via localStorage.

# Changes

- Add CSS custom properties for theme colors (`--theme-50` through `--theme-950`) with palettes for each theme, mapped through Tailwind's `@theme` directive
- Add `ThemeContext` with `ThemeWrapper` provider and `useTheme` hook for theme state management
- Add inline script in `_document.tsx` to apply the saved theme before first paint, avoiding flash of default theme
- Add `ThemeSubmenu` dropdown in the nav header for theme selection with color dot previews
- Replace all hardcoded `sky-*` / `text-sky-*` color classes with `theme-*` equivalents across components
- Fix `<title>` hydration warning caused by multiple child nodes in SEO component

# Files changed

- `src/styles/globals.css` — Theme CSS variables and `@theme` registration
- `src/shared/contexts/ThemeContext.tsx` — Theme context, provider, and hook
- `src/pages/_document.tsx` — Inline script for pre-render theme application
- `src/pages/_app.tsx` — Wrap app with `ThemeWrapper`
- `src/shared/components/navigation/NavHeader/components/MoreButton/` — Refactored to directory, added `ThemeSubmenu`
- `src/styles/calendar.css` — Replaced `sky-*` with `theme-*`
- `src/shared/components/SEO.tsx` — Fix title hydration warning
- Various widget/component files — Replaced hardcoded `sky-*` classes with `theme-*`


## Demo

<img width="1271" height="944" alt="user selectable theme-selector" src="https://github.com/user-attachments/assets/fb2af133-4d0b-4cf5-9f26-ec03f4bebf11" />



